### PR TITLE
mshv-ioctls: fix unmap_user_region's name

### DIFF
--- a/mshv-ioctls/src/ioctls/vm.rs
+++ b/mshv-ioctls/src/ioctls/vm.rs
@@ -98,7 +98,7 @@ impl VmFd {
     ///
     /// Unmap a guest physical memory.
     ///
-    pub fn umap_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
+    pub fn unmap_user_memory(&self, user_memory_region: mshv_user_mem_region) -> Result<()> {
         #[allow(clippy::cast_lossless)]
         let ret = unsafe { ioctl_with_ref(self, MSHV_UNMAP_GUEST_MEMORY(), &user_memory_region) };
         if ret == 0 {
@@ -455,7 +455,7 @@ mod tests {
 
         vm.map_user_memory(mem).unwrap();
 
-        vm.umap_user_memory(mem).unwrap();
+        vm.unmap_user_memory(mem).unwrap();
     }
     #[test]
     fn test_create_vcpu() {


### PR DESCRIPTION
Signed-off-by: Wei Liu <liuwe@microsoft.com>